### PR TITLE
Allow passing of extra arguments to rsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ docker run --rm \
   -e PLUGIN_HOSTS="127.0.0.1" \
   -e PLUGIN_TARGET="./" \
   -e PLUGIN_SCRIPT="echo \"Done!\"" \
+  -e PLUGIN_ARGS="--blocking-io" \
   -v $(pwd):$(pwd) \
   -w $(pwd) \
   drillster/drone-rsync

--- a/upload.sh
+++ b/upload.sh
@@ -41,8 +41,14 @@ if [ -z "$RSYNC_KEY" ]; then
     SSH_KEY=$PLUGIN_KEY
 fi
 
+if [ -z "$PLUGIN_ARGS" ]; then
+    ARGS=
+else
+    ARGS=$PLUGIN_ARGS
+fi
+
 # Building rsync command
-expr="rsync -az"
+expr="rsync -az $ARGS"
 
 if [[ -n "$PLUGIN_RECURSIVE" && "$PLUGIN_RECURSIVE" == "true" ]]; then
     expr="$expr -r"


### PR DESCRIPTION
This PR allows the passing of extra arguments to rsync.

I found that executing commands via rsync wouldn't exit and caused my builds to time out. 

For my use case, I needed to pass the `--blocking-io` option to rsync but figured this may be useful for other cases.

Refs:
https://github.com/docker/docker/issues/13660#issuecomment-192975035
https://github.com/jpetazzo/nsenter/issues/67#issuecomment-211336087 