### PR TITLE
Use ecdsa or ed25519 for the SSH_KEY if required

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -88,8 +88,19 @@ mkdir -p "$home/.ssh"
 printf "StrictHostKeyChecking no\n" > "$home/.ssh/config"
 chmod 0700 "$home/.ssh/config"
 
-echo "$SSH_KEY" > "$home/.ssh/id_rsa"
-chmod 0600 "$home/.ssh/id_rsa"
+keyfile="$home/.ssh/id_rsa"
+echo "$SSH_KEY" | grep -q "ssh-ed25519"
+if [ $? -eq 0 ]; then
+    printf "Using ed25519 based key\n"
+    keyfile="$home/.ssh/id_ed25519"
+fi
+echo "$SSH_KEY" | grep -q "ecdsa-"
+if [ $? -eq 0 ]; then
+    printf "Using ecdsa based key\n"
+    keyfile="$home/.ssh/id_ecdsa"
+fi
+echo "$SSH_KEY" > $keyfile
+chmod 0600 $keyfile
 
 # Parse SSH commands
 function join_with { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }


### PR DESCRIPTION
Currently this will not connect if the server forces a particular key type such as ed25519 which can prevent the script from connecting. This allows the server to connect if it detects a particular key in use by the user.

Not included in this change is a DSA key since they are typically being depreciated and therefore not recommended.