### PR TITLE
Accept key secret compatibility with drone-ssh

### DIFF
--- a/DOCS.md
+++ b/DOCS.md
@@ -7,12 +7,13 @@ The following parameters are used to configure the plugin:
 - **hosts** - hostnames or ip-addresses of the remote machines
 - **port** - port to connect to on the remote machines, defaults to `22`
 - **source** - source folder to synchronize from, defaults to `./`
-- **target** - target folder on remote machines to synchronize to
+- **target** - target folder to synchronize to
 - **include** - rsync include filter
 - **exclude** - rsync exclude filter
 - **recursive** - recursively synchronize, defaults to `false`
 - **delete** - delete target folder contents, defaults to `false`
 - **script** - list of commands to execute on remote machines
+- **pull** - rsync from the hosts to the working directory, defaults to `false`
 
 ## Secrets
 The following secrets can be used to secure the sensitive parts of your configuration:

--- a/DOCS.md
+++ b/DOCS.md
@@ -13,7 +13,7 @@ The following parameters are used to configure the plugin:
 - **recursive** - recursively synchronize, defaults to `false`
 - **delete** - delete target folder contents, defaults to `false`
 - **script** - list of commands to execute on remote machines
-- **pull** - rsync from the hosts to the working directory, defaults to `false`
+- **rsync_pull** - rsync from the hosts to the working directory, defaults to `false`
 
 ## Secrets
 The following secrets can be used to secure the sensitive parts of your configuration:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM alpine:3.4
 MAINTAINER Michael de Wit <michael@drillster.com>
 
 RUN apk add --no-cache ca-certificates bash openssh-client rsync
-COPY upload.sh /usr/local/
+COPY transfer.sh /usr/local/
 
 ENTRYPOINT ["/usr/local/transfer.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,4 @@ MAINTAINER Michael de Wit <michael@drillster.com>
 RUN apk add --no-cache ca-certificates bash openssh-client rsync
 COPY upload.sh /usr/local/
 
-ENTRYPOINT ["/usr/local/upload.sh"]
+ENTRYPOINT ["/usr/local/transfer.sh"]

--- a/README.md
+++ b/README.md
@@ -1,9 +1,16 @@
 # drone-rsync
-[![drone-rsync on Docker Hub](https://img.shields.io/docker/automated/drillster/drone-rsync.svg)](https://hub.docker.com/r/drillster/drone-rsync/)
+[drone-rsync on Docker Hub](https://hub.docker.com/r/toreilly/drone-rsync/)
 
-This is a pure Bash [Drone](https://github.com/drone/drone) >= 0.5 plugin to sync files to remote hosts.
+This is a pure Bash [Drone](https://github.com/drone/drone) plugin to sync files to remote hosts.
+It is a fork of [Drillster/drone-rsync](https://github.com/Drillster/drone-rsync) in order to add pull support.
 
-For more information on how to use the plugin, please take a look at [the docs](https://github.com/Drillster/drone-rsync/blob/master/DOCS.md).
+For more information on how to use the plugin, please take a look at [the docs](https://github.com/tommyo/drone-rsync/blob/master/DOCS.md).
+
+## Added feature
+
+Add `rysnc_pull: true` to your yaml to pull files rather than push.
+
+The `script` section still runs remotely. This flag only changes file transfer behavior.
 
 ## Docker
 Build the docker image by running:
@@ -19,7 +26,9 @@ Execute from the working directory (assuming you have an SSH server running on 1
 docker run --rm \
   -e PLUGIN_KEY=$(cat some-private-key) \
   -e PLUGIN_HOSTS="127.0.0.1" \
+  -e PLUGIN_SOURCE="./my_remote_file.tgz" \
   -e PLUGIN_TARGET="./" \
+  -e PLUGIN_RSYNC_PULL="true" \
   -e PLUGIN_SCRIPT="echo \"Done!\"" \
   -e PLUGIN_ARGS="--blocking-io" \
   -v $(pwd):$(pwd) \

--- a/transfer.sh
+++ b/transfer.sh
@@ -80,8 +80,6 @@ for filter in "${FILTER[@]}"; do
     expr="$expr --filter=$filter"
 done
 
-expr="$expr $SOURCE"
-
 # Prepare SSH
 home="/root"
 
@@ -113,8 +111,14 @@ script=$(join_with ' && ' "${COMMANDS[@]}")
 IFS=','; read -ra HOSTS <<< "$PLUGIN_HOSTS"
 result=0
 for host in "${HOSTS[@]}"; do
-    echo $(printf "%s" "$ $expr $USER@$host:$PLUGIN_TARGET ...")
-    eval "$expr $USER@$host:$PLUGIN_TARGET"
+    from=$SOURCE
+    to=$USER@$host:$PLUGIN_TARGET
+    if [[ -n "$PLUGIN_PULL" && "$PLUGIN_PULL" == "true" ]]; then
+        from=$USER@$host:$SOURCE
+        to=$PLUGIN_TARGET
+    fi
+    echo $(printf "%s" "$ $expr $from $to ...")
+    eval "$expr $from $to"
     result=$(($result+$?))
     if [ "$result" -gt "0" ]; then exit $result; fi
     if [ -n "$PLUGIN_SCRIPT" ]; then

--- a/transfer.sh
+++ b/transfer.sh
@@ -113,7 +113,7 @@ result=0
 for host in "${HOSTS[@]}"; do
     from=$SOURCE
     to=$USER@$host:$PLUGIN_TARGET
-    if [[ -n "$PLUGIN_PULL" && "$PLUGIN_PULL" == "true" ]]; then
+    if [[ -n "$PLUGIN_RSYNC_PULL" && "$PLUGIN_RSYNC_PULL" == "true" ]]; then
         from=$USER@$host:$SOURCE
         to=$PLUGIN_TARGET
     fi

--- a/upload.sh
+++ b/upload.sh
@@ -32,13 +32,15 @@ if [ -z "$RSYNC_USER" ]; then
     fi
 fi
 
-SSH_KEY=$RSYNC_KEY
-if [ -z "$RSYNC_KEY" ]; then
-    if [ -z "$PLUGIN_KEY" ]; then
-        echo "No private key specified!"
-        exit 1
-    fi
+if [ -n "$PLUGIN_KEY" ]; then
     SSH_KEY=$PLUGIN_KEY
+fi
+if [ -n "$RSYNC_KEY" ]; then
+    SSH_KEY=$RSYNC_KEY
+fi
+if [ -z "$SSH_KEY" ]; then
+    echo "No private key specified!"
+    exit 1
 fi
 
 if [ -z "$PLUGIN_ARGS" ]; then


### PR DESCRIPTION
Allows SSH_KEY to be passed as a secret, and maintains key priorities as: RSYNC_KEY > PLUGIN_KEY > SSH_KEY

It is often better to break the rsync and ssh scripts into different stages in drone. Currently this means registering the same key in secrets under two different secret names: RSYNC_KEY and SSH_KEY.

This patch gives the option to share the SSH_KEY if set to alleviate key secrets management in drone.