### PR TITLE
Add the support of local scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,14 @@ docker run --rm \
   -e PLUGIN_PRESCRIPT="echo \"Prescript Done!\"" \
   -e PLUGIN_SCRIPT="echo \"Postscript Done!\"" \
   -e PLUGIN_ARGS="--blocking-io" \
+  -e PLUGIN_LOCALSCRIPT="echo \"Localscript Done!\"" \
   -v $(pwd):$(pwd) \
   -w $(pwd) \
   drillster/drone-rsync
 ```
+
+## Updates
+### 2022-03-15
+Add the support of local scripts, that could be run on local server before rsync to remote server.
+This is required because when target server got lower version of openSSH, and it's impossible to upgrade the target server, so adopt a local script feature to run below before sync files.
+`echo -e "Host xxx.xxx.xxx.xxx\n    KexAlgorithms +diffie-hellman-group1-sha1" >> ~/.ssh/config`

--- a/upload.sh
+++ b/upload.sh
@@ -47,9 +47,9 @@ else
 fi
 
 if [ -z "$PLUGIN_LOCALSCRIPT" ]; then
-    LOCALSCRIPT=
+    LOCALSCRIPTS=
 else
-    LOCALSCRIPT=$PLUGIN_LOCALSCRIPT
+    IFS=','; read -ra LOCALSCRIPTS <<< "$PLUGIN_LOCALSCRIPT"
 fi
 
 # Building rsync command
@@ -122,9 +122,13 @@ IFS=','; read -ra PORTS <<< "$PLUGIN_PORTS"
 result=0
 
 # Run local script
-if [[ -n "$LOCALSCRIPT" ]]; then
-    echo $(printf "%s" " (local)> $LOCALSCRIPT ...")
-    eval "$LOCALSCRIPT"
+if [[ -n "$LOCALSCRIPTS" ]]; then
+    for ((i=0; i < ${#LOCALSCRIPTS[@]}; i++))
+    do
+        LOCALSCRIPT=${LOCALSCRIPTS[$i]}
+        echo $(printf "%s" " (local)> $LOCALSCRIPT ...")
+        eval "$LOCALSCRIPT"
+    done
 fi
 
 for ((i=0; i < ${#HOSTS[@]}; i++))

--- a/upload.sh
+++ b/upload.sh
@@ -46,6 +46,12 @@ else
     ARGS=$PLUGIN_ARGS
 fi
 
+if [ -z "$PLUGIN_LOCALSCRIPT" ]; then
+    LOCALSCRIPT=
+else
+    LOCALSCRIPT=$PLUGIN_LOCALSCRIPT
+fi
+
 # Building rsync command
 expr="rsync -az $ARGS"
 
@@ -114,6 +120,13 @@ postscript=$(join_with ' && ' "${COMMANDS[@]}")
 IFS=','; read -ra HOSTS <<< "$PLUGIN_HOSTS"
 IFS=','; read -ra PORTS <<< "$PLUGIN_PORTS"
 result=0
+
+# Run local script
+if [[ -n "$LOCALSCRIPT" ]]; then
+    echo $(printf "%s" " (local)> $LOCALSCRIPT ...")
+    eval "$LOCALSCRIPT"
+fi
+
 for ((i=0; i < ${#HOSTS[@]}; i++))
 do
     HOST=${HOSTS[$i]}


### PR DESCRIPTION
Add the support of local scripts, that could be run on local server before rsync to remote server. 

This is required by my project because when target server got lower version of openSSH, and it's impossible to upgrade the target server, so adopt a local script feature to run below before sync files. 
`echo -e "Host xxx.xxx.xxx.xxx\n KexAlgorithms +diffie-hellman-group1-sha1" >> ~/.ssh/config`