### PR TITLE
Multiple scripts do not concatenate strings using && as expected.

### DIFF
--- a/upload.sh
+++ b/upload.sh
@@ -107,7 +107,18 @@ fi
 echo "$SSH_KEY" > $keyfile
 chmod 0600 $keyfile
 
-function join_with { local d=$1; shift; echo -n "$1"; shift; printf "%s" "${@/#/$d}"; }
+function join_with {
+    local d=$1
+    shift
+    local result="$1"
+    shift
+
+    for item in "$@"; do
+        result+="$d$item"
+    done
+
+    echo "$result"
+}
 
 # Parse SSH precommands
 IFS=','; read -ra COMMANDS <<< "$PLUGIN_PRESCRIPT"


### PR DESCRIPTION
This PR fixes the bug described in #42 
Fixed the issue that after upgrading bash 5.1.16 to 5.2.26, the version difference caused multiple scripts to fail to use && to concatenate strings as expected.